### PR TITLE
Fix plugin to run on 2019.2 - 2019.3 with Kotlin 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/test-project/out/

--- a/build.gradle
+++ b/build.gradle
@@ -26,15 +26,15 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.3"
-    compile "org.jetbrains.kotlin:kotlin-reflect:1.0.3"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:1.3.31"
+    compile "org.jetbrains.kotlin:kotlin-reflect:1.3.31"
     compile 'com.github.yole.jitwatch:core:18be9ec'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 
 intellij {
-    version 'IC-2016.2'
-    plugins = ['org.jetbrains.kotlin:1.0.3-release-IJ2016.1-103']
+    version 'IC-2018.1'
+    plugins = ['org.jetbrains.kotlin:1.3.31-release-IJ2018.1-1']
 }
 
 publishPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,9 @@ dependencies {
 
 intellij {
     version "$ideaVersion"
-    plugins = ["org.jetbrains.kotlin:$kotlinPluginVersion"]
+    plugins = [
+            "org.jetbrains.kotlin:$kotlinPluginVersion"
+    ]
 }
 
 // Read sinceBuild/untilBuild from gradle-$platformVersion.properties

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group 'ru.yole'
-version '1.0'
+version "${pluginVersion}-${platformVersion}"
 
 
 sourceCompatibility = 1.5
@@ -45,7 +45,6 @@ intellij {
 // Read sinceBuild/untilBuild from gradle-$platformVersion.properties
 patchPluginXml.sinceBuild = sinceBuild
 patchPluginXml.untilBuild = untilBuild
-patchPluginXml.version = "${pluginVersion}"
 
 sourceSets {
     main {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
 group 'ru.yole'
 version "${pluginVersion}-${platformVersion}"
 
+def isAtLeast192 = platformVersion.toInteger() >= 192
 
 sourceCompatibility = 1.5
 
@@ -36,10 +37,10 @@ dependencies {
 
 intellij {
     version "$ideaVersion"
-    plugins = [
-            "java",
-            "org.jetbrains.kotlin:$kotlinPluginVersion"
-    ]
+    if (isAtLeast192) {
+        plugins += "java"
+    }
+    plugins += "org.jetbrains.kotlin:$kotlinPluginVersion"
 }
 
 // Read sinceBuild/untilBuild from gradle-$platformVersion.properties

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 intellij {
     version "$ideaVersion"
     plugins = [
+            "java",
             "org.jetbrains.kotlin:$kotlinPluginVersion"
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,19 +4,19 @@ buildscript {
         maven { url 'http://dl.bintray.com/jetbrains/intellij-plugin-service' }
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.3"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
     }
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.1.6"
+    id "org.jetbrains.intellij" version "0.4.8"
+    id "java"
+    id ("org.jetbrains.kotlin.jvm") version "1.3.31"
 }
 
 group 'ru.yole'
 version '1.0'
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
 
 sourceCompatibility = 1.5
 
@@ -35,13 +35,14 @@ dependencies {
 intellij {
     version 'IC-2016.2'
     plugins = ['org.jetbrains.kotlin:1.0.3-release-IJ2016.1-103']
-
-    publish {
-        username System.getenv('JETBRAINS_USER')
-        password System.getenv('JETBRAINS_PASSWORD')
-    }
 }
 
+publishPlugin {
+    username System.getenv('JETBRAINS_USER')
+    password System.getenv('JETBRAINS_PASSWORD')
+}
+
+
 project.afterEvaluate {
-    project.tasks.runIdea.maxHeapSize = "2048m"
+    project.tasks.runIde.maxHeapSize = "2048m"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ sourceSets {
     }
 }
 
+runIde{
+    args "${project.projectDir}/test-project"
+}
+
 publishPlugin {
     username System.getenv('JETBRAINS_USER')
     password System.getenv('JETBRAINS_PASSWORD')

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
+        classpath "net.saliman:gradle-properties-plugin:1.4.6"
     }
 }
 
@@ -12,6 +13,7 @@ plugins {
     id "org.jetbrains.intellij" version "0.4.8"
     id "java"
     id ("org.jetbrains.kotlin.jvm") version "1.3.31"
+    id "net.saliman.properties" version "1.4.6"
 }
 
 group 'ru.yole'
@@ -33,8 +35,23 @@ dependencies {
 }
 
 intellij {
-    version 'IC-2018.1'
-    plugins = ['org.jetbrains.kotlin:1.3.31-release-IJ2018.1-1']
+    version "$ideaVersion"
+    plugins = ["org.jetbrains.kotlin:$kotlinPluginVersion"]
+}
+
+// Read sinceBuild/untilBuild from gradle-$platformVersion.properties
+patchPluginXml.sinceBuild = sinceBuild
+patchPluginXml.untilBuild = untilBuild
+
+sourceSets {
+    main {
+        for (String platformSpecificSrcDir : "$platformSpecificSrcDirs".split(",")) {
+            if (!platformSpecificSrcDir.isEmpty()) {
+                // prevent empty platformSpecificSrcDirs entries from doing anything
+                java.srcDirs("src/$platformSpecificSrcDir/java")
+            }
+        }
+    }
 }
 
 publishPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ intellij {
 // Read sinceBuild/untilBuild from gradle-$platformVersion.properties
 patchPluginXml.sinceBuild = sinceBuild
 patchPluginXml.untilBuild = untilBuild
+patchPluginXml.version = "${pluginVersion}"
 
 sourceSets {
     main {

--- a/gradle-181.properties
+++ b/gradle-181.properties
@@ -3,7 +3,7 @@ ideaVersion=IC-2018.1.6
 kotlinPluginVersion=1.3.31-release-IJ2018.1-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=181.*
+sinceBuild=181
 untilBuild=181.*
 
 platformSpecificSrcDirs=181-182

--- a/gradle-181.properties
+++ b/gradle-181.properties
@@ -1,5 +1,5 @@
 ideaVersion=IC-2018.1.6
-# plaease see # please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+# please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
 kotlinPluginVersion=1.3.31-release-IJ2018.1-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description

--- a/gradle-181.properties
+++ b/gradle-181.properties
@@ -1,0 +1,9 @@
+ideaVersion=IC-2018.1.6
+# plaease see # please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+kotlinPluginVersion=1.3.31-release-IJ2018.1-1
+
+# please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
+sinceBuild=181.*
+untilBuild=181.*
+
+platformSpecificSrcDirs=181-182

--- a/gradle-182.properties
+++ b/gradle-182.properties
@@ -4,5 +4,5 @@ kotlinPluginVersion=1.3.31-release-IJ2018.2-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 platformSpecificSrcDirs=181-182
-sinceBuild=182.*
+sinceBuild=182
 untilBuild=182.*

--- a/gradle-182.properties
+++ b/gradle-182.properties
@@ -1,5 +1,5 @@
 ideaVersion=IC-2018.2.6
-# plaease see # please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+# please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
 kotlinPluginVersion=1.3.31-release-IJ2018.2-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description

--- a/gradle-182.properties
+++ b/gradle-182.properties
@@ -1,0 +1,8 @@
+ideaVersion=IC-2018.2.6
+# plaease see # please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+kotlinPluginVersion=1.3.31-release-IJ2018.2-1
+
+# please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
+platformSpecificSrcDirs=181-182
+sinceBuild=182.*
+untilBuild=182.*

--- a/gradle-183.properties
+++ b/gradle-183.properties
@@ -5,4 +5,4 @@ kotlinPluginVersion=1.3.31-release-IJ2018.3-1
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=183.4886
 untilBuild=183.*
-platformSpecificSrcDirs=
+platformSpecificSrcDirs=183-191

--- a/gradle-183.properties
+++ b/gradle-183.properties
@@ -1,0 +1,8 @@
+ideaVersion=IC-2018.3.6
+# please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+kotlinPluginVersion=1.3.31-release-IJ2018.3-1
+
+# please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
+sinceBuild=183.4886
+untilBuild=183.*
+platformSpecificSrcDirs=

--- a/gradle-191.properties
+++ b/gradle-191.properties
@@ -5,3 +5,4 @@ kotlinPluginVersion=1.3.31-release-IJ2019.1-1
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=191.6183
 untilbuild=192.*
+platformSpecificSrcDirs=183-191

--- a/gradle-191.properties
+++ b/gradle-191.properties
@@ -4,5 +4,5 @@ kotlinPluginVersion=1.3.31-release-IJ2019.1-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=191.6183
-untilBuild=192.*
+untilBuild=191.*
 platformSpecificSrcDirs=183-191

--- a/gradle-191.properties
+++ b/gradle-191.properties
@@ -4,5 +4,5 @@ kotlinPluginVersion=1.3.31-release-IJ2019.1-1
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=191.6183
-untilbuild=192.*
+untilBuild=192.*
 platformSpecificSrcDirs=183-191

--- a/gradle-191.properties
+++ b/gradle-191.properties
@@ -1,0 +1,7 @@
+ideaVersion=IC-2019.1.2
+# please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+kotlinPluginVersion=1.3.31-release-IJ2019.1-1
+
+# please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
+sinceBuild=191.6183
+untilbuild=192.*

--- a/gradle-192.properties
+++ b/gradle-192.properties
@@ -1,0 +1,8 @@
+ideaVersion=IC-2019.2
+# please see https://plugins.jetbrains.com/plugin/6954-kotlin/versions
+kotlinPluginVersion=1.3.41-release-IJ2019.2-1
+
+# please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
+sinceBuild=192.4787.16
+untilBuild=192.*
+platformSpecificSrcDirs=183-191

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+propertiesPluginEnvironmentNameProperty=platformVersion
+platformVersion=183

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 platformVersion=191
+pluginVersion=1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
-platformVersion=183
+platformVersion=191

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
-platformVersion=191
-pluginVersion=1.0.1
+platformVersion=192
+pluginVersion=1.0.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip

--- a/src/181-182/java/InlineStructurePopup.kt
+++ b/src/181-182/java/InlineStructurePopup.kt
@@ -1,0 +1,99 @@
+package ru.yole.jitwatch
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.util.treeView.AbstractTreeStructure
+import com.intellij.ide.util.treeView.NodeDescriptor
+import com.intellij.ide.util.treeView.PresentableNodeDescriptor
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.LangDataKeys
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.PopupStep
+import com.intellij.openapi.ui.popup.util.BaseTreePopupStep
+import com.intellij.pom.Navigatable
+import com.intellij.ui.SimpleTextAttributes
+import org.adoptopenjdk.jitwatch.chain.CompileChainWalker
+import org.adoptopenjdk.jitwatch.chain.CompileNode
+import org.adoptopenjdk.jitwatch.model.IMetaMember
+import ru.yole.jitwatch.languages.LanguageSupport
+import ru.yole.jitwatch.languages.forElement
+
+class InlineTreeStructure(val project: Project, val root: CompileNode) : AbstractTreeStructure() {
+    override fun getRootElement() = InlineTreeNodeDescriptor(project, null, root, true)
+
+    override fun createDescriptor(element: Any?, parentDescriptor: NodeDescriptor<*>?) = element as NodeDescriptor<*>
+
+    override fun getParentElement(element: Any?) = (element as InlineTreeNodeDescriptor).parentDescriptor
+
+    override fun getChildElements(element: Any?) =
+            (element as InlineTreeNodeDescriptor).compileNode.children
+                    .map { InlineTreeNodeDescriptor(project, element as NodeDescriptor<*>, it )}
+                    .toTypedArray()
+
+    override fun commit() {
+    }
+
+    override fun hasSomethingToCommit() = false
+}
+
+class InlineTreeNodeDescriptor(project: Project,
+                               parentDescriptor: NodeDescriptor<*>?,
+                               val compileNode: CompileNode,
+                               val isRoot: Boolean = false)
+        : PresentableNodeDescriptor<CompileNode>(project, parentDescriptor)
+{
+    override fun update(presentation: PresentationData) {
+        presentation.addText(compileNode.member?.presentableName() ?: "<Unknown>",
+                if (compileNode.isInlined || isRoot)
+                    SimpleTextAttributes.REGULAR_ATTRIBUTES
+                else
+                    SimpleTextAttributes.ERROR_ATTRIBUTES)
+        presentation.tooltip = compileNode.tooltipText
+    }
+
+    override fun getElement() = compileNode
+}
+
+class ShowInlineStructureAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val metaMember = findTargetMember(e) ?: return
+        val project = e.project!!
+        val modelService = JitWatchModelService.getInstance(project)
+        val compileChainWalker = CompileChainWalker(modelService.model)
+        val compileNode = compileChainWalker.buildCallTree(metaMember.journal) ?: return
+        val treeStructure = InlineTreeStructure(project, compileNode)
+        val popupStep = object : BaseTreePopupStep<InlineTreeNodeDescriptor>(project, "Inline", treeStructure) {
+            override fun isRootVisible() = true
+
+            override fun onChosen(selectedValue: InlineTreeNodeDescriptor?, finalChoice: Boolean): PopupStep<*>? {
+                if (selectedValue != null) {
+                    val psiMember = JitWatchModelService.getInstance(project).getPsiMember(selectedValue.compileNode.member)
+                    (psiMember as? Navigatable)?.navigate(true)
+                }
+                return PopupStep.FINAL_CHOICE
+            }
+        }
+        JBPopupFactory.getInstance().createTree(popupStep).showInBestPositionFor(e.dataContext)
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = findTargetMember(e) != null
+    }
+
+    private fun findTargetMember(e: AnActionEvent): IMetaMember? {
+        val project = e.project ?: return null
+        val modelService = JitWatchModelService.getInstance(project)
+        if (modelService.model == null) return null
+        val psiElement = e.getData(LangDataKeys.PSI_ELEMENT) ?: return null
+        val languageSupport = LanguageSupport.forElement(psiElement)
+        if (languageSupport.isMethod(psiElement)) {
+            return modelService.getMetaMember(psiElement)
+        }
+        return null
+    }
+}
+
+fun IMetaMember.presentableName(): String {
+    return (metaClass?.name ?: "<unknown>") + "." + memberName
+}

--- a/src/181-182/java/JitRunConfigurationExtension.kt
+++ b/src/181-182/java/JitRunConfigurationExtension.kt
@@ -1,0 +1,119 @@
+package ru.yole.jitwatch
+
+import com.intellij.execution.CommonJavaRunConfigurationParameters
+import com.intellij.execution.RunConfigurationExtension
+import com.intellij.execution.configurations.JavaParameters
+import com.intellij.execution.configurations.RunConfigurationBase
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.wm.ToolWindowManager
+import org.jdom.Element
+import java.awt.BorderLayout
+import java.io.File
+import javax.swing.JCheckBox
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+private const val JITWATCH_ENABLED_ATTRIBUTE = "jitwatch-enabled"
+
+data class JitWatchSettings(var enabled: Boolean = false, var lastLogPath: File? = null) {
+    companion object {
+        private val KEY: Key<JitWatchSettings> = Key.create("ru.yole.jitwatch.settings")
+
+        fun getOrCreate(configuration: RunConfigurationBase): JitWatchSettings {
+            var settings = configuration.getUserData(KEY)
+            if (settings == null) {
+                settings = JitWatchSettings()
+                configuration.putUserData(KEY, settings)
+            }
+            return settings
+        }
+
+        fun clear(configuration: RunConfigurationBase) {
+            configuration.putUserData(KEY, null)
+        }
+    }
+}
+
+class JitRunConfigurationExtension : RunConfigurationExtension() {
+    override fun <P : RunConfigurationBase> createEditor(configuration: P): SettingsEditor<P>? {
+        return JitRunConfigurationEditor()
+    }
+
+    override fun cleanUserData(runConfigurationBase: RunConfigurationBase) {
+        JitWatchSettings.clear(runConfigurationBase)
+    }
+
+    override fun getEditorTitle() = "JITWatch"
+
+    override fun isApplicableFor(configuration: RunConfigurationBase) = configuration is CommonJavaRunConfigurationParameters
+
+    override fun readExternal(runConfiguration: RunConfigurationBase, element: Element) {
+        val settings = JitWatchSettings.getOrCreate(runConfiguration)
+        settings.enabled = element.getAttributeValue(JITWATCH_ENABLED_ATTRIBUTE) == "true"
+    }
+
+    override fun writeExternal(runConfiguration: RunConfigurationBase, element: Element) {
+        val settings = JitWatchSettings.getOrCreate(runConfiguration)
+        if (settings.enabled) {
+            element.setAttribute(JITWATCH_ENABLED_ATTRIBUTE, "true")
+        }
+    }
+
+    override fun <T : RunConfigurationBase> updateJavaParameters(configuration: T,
+                                                                 params: JavaParameters,
+                                                                 runnerSettings: RunnerSettings?) {
+        val settings = JitWatchSettings.getOrCreate(configuration)
+        if (settings.enabled) {
+            val logPath = FileUtil.generateRandomTemporaryPath()
+            val vmOptions = params.vmParametersList
+            vmOptions.add("-XX:+UnlockDiagnosticVMOptions")
+            vmOptions.add("-XX:+TraceClassLoading")
+            vmOptions.add("-XX:+LogCompilation")
+            vmOptions.add("-XX:LogFile=" + logPath.absolutePath)
+            settings.lastLogPath = logPath
+        }
+    }
+
+    override fun attachToProcess(configuration: RunConfigurationBase, handler: ProcessHandler, runnerSettings: RunnerSettings?) {
+        val logPath = JitWatchSettings.getOrCreate(configuration).lastLogPath
+        if (logPath != null) {
+            handler.addProcessListener(object : ProcessAdapter() {
+                override fun processTerminated(event: ProcessEvent) {
+                    ApplicationManager.getApplication().invokeLater {
+                        loadLogAndShowUI(configuration.project, logPath)
+                    }
+                }
+            })
+        }
+    }
+}
+
+private class JitRunConfigurationEditor<T : RunConfigurationBase> : SettingsEditor<T>() {
+    private val editorPanel = JPanel(BorderLayout())
+    private val enabledCheckbox = JCheckBox("Log compilation")
+
+    init {
+        editorPanel.add(enabledCheckbox, BorderLayout.NORTH)
+    }
+
+    override fun applyEditorTo(s: T) {
+        val settings = JitWatchSettings.getOrCreate(s)
+        settings.enabled = enabledCheckbox.isSelected
+    }
+
+    override fun resetEditorFrom(s: T) {
+        val settings = JitWatchSettings.getOrCreate(s)
+        enabledCheckbox.isSelected = settings.enabled
+    }
+
+    override fun createEditor(): JComponent {
+        return editorPanel
+    }
+}

--- a/src/183-191/java/InlineStructurePopup.kt
+++ b/src/183-191/java/InlineStructurePopup.kt
@@ -22,11 +22,11 @@ import ru.yole.jitwatch.languages.forElement
 class InlineTreeStructure(val project: Project, val root: CompileNode) : AbstractTreeStructure() {
     override fun getRootElement() = InlineTreeNodeDescriptor(project, null, root, true)
 
-    override fun createDescriptor(element: Any?, parentDescriptor: NodeDescriptor<*>?) = element as NodeDescriptor<*>
+    override fun createDescriptor(element: Any, parentDescriptor: NodeDescriptor<*>?) = element as NodeDescriptor<*>
 
-    override fun getParentElement(element: Any?) = (element as InlineTreeNodeDescriptor).parentDescriptor
+    override fun getParentElement(element: Any) = (element as InlineTreeNodeDescriptor).parentDescriptor
 
-    override fun getChildElements(element: Any?) =
+    override fun getChildElements(element: Any) =
             (element as InlineTreeNodeDescriptor).compileNode.children
                     .map { InlineTreeNodeDescriptor(project, element as NodeDescriptor<*>, it )}
                     .toTypedArray()

--- a/src/183-191/java/JitRunConfigurationExtension.kt
+++ b/src/183-191/java/JitRunConfigurationExtension.kt
@@ -26,7 +26,7 @@ data class JitWatchSettings(var enabled: Boolean = false, var lastLogPath: File?
     companion object {
         private val KEY: Key<JitWatchSettings> = Key.create("ru.yole.jitwatch.settings")
 
-        fun getOrCreate(configuration: RunConfigurationBase): JitWatchSettings {
+        fun getOrCreate(configuration: RunConfigurationBase<*>): JitWatchSettings {
             var settings = configuration.getUserData(KEY)
             if (settings == null) {
                 settings = JitWatchSettings()
@@ -35,38 +35,38 @@ data class JitWatchSettings(var enabled: Boolean = false, var lastLogPath: File?
             return settings
         }
 
-        fun clear(configuration: RunConfigurationBase) {
+        fun clear(configuration: RunConfigurationBase<*>) {
             configuration.putUserData(KEY, null)
         }
     }
 }
 
 class JitRunConfigurationExtension : RunConfigurationExtension() {
-    override fun <P : RunConfigurationBase> createEditor(configuration: P): SettingsEditor<P>? {
+    override fun <P : RunConfigurationBase<*>> createEditor(configuration: P): SettingsEditor<P>? {
         return JitRunConfigurationEditor()
     }
 
-    override fun cleanUserData(runConfigurationBase: RunConfigurationBase) {
+    override fun cleanUserData(runConfigurationBase: RunConfigurationBase<*>) {
         JitWatchSettings.clear(runConfigurationBase)
     }
 
     override fun getEditorTitle() = "JITWatch"
 
-    override fun isApplicableFor(configuration: RunConfigurationBase) = configuration is CommonJavaRunConfigurationParameters
+    override fun isApplicableFor(configuration: RunConfigurationBase<*>) = configuration is CommonJavaRunConfigurationParameters
 
-    override fun readExternal(runConfiguration: RunConfigurationBase, element: Element) {
+    override fun readExternal(runConfiguration: RunConfigurationBase<*>, element: Element) {
         val settings = JitWatchSettings.getOrCreate(runConfiguration)
         settings.enabled = element.getAttributeValue(JITWATCH_ENABLED_ATTRIBUTE) == "true"
     }
 
-    override fun writeExternal(runConfiguration: RunConfigurationBase, element: Element) {
+    override fun writeExternal(runConfiguration: RunConfigurationBase<*>, element: Element) {
         val settings = JitWatchSettings.getOrCreate(runConfiguration)
         if (settings.enabled) {
             element.setAttribute(JITWATCH_ENABLED_ATTRIBUTE, "true")
         }
     }
 
-    override fun <T : RunConfigurationBase> updateJavaParameters(configuration: T,
+    override fun <T : RunConfigurationBase<*>> updateJavaParameters(configuration: T,
                                                                  params: JavaParameters,
                                                                  runnerSettings: RunnerSettings?) {
         val settings = JitWatchSettings.getOrCreate(configuration)
@@ -81,7 +81,7 @@ class JitRunConfigurationExtension : RunConfigurationExtension() {
         }
     }
 
-    override fun attachToProcess(configuration: RunConfigurationBase, handler: ProcessHandler, runnerSettings: RunnerSettings?) {
+    override fun attachToProcess(configuration: RunConfigurationBase<*>, handler: ProcessHandler, runnerSettings: RunnerSettings?) {
         val logPath = JitWatchSettings.getOrCreate(configuration).lastLogPath
         if (logPath != null) {
             handler.addProcessListener(object : ProcessAdapter() {
@@ -95,7 +95,7 @@ class JitRunConfigurationExtension : RunConfigurationExtension() {
     }
 }
 
-private class JitRunConfigurationEditor<T : RunConfigurationBase> : SettingsEditor<T>() {
+private class JitRunConfigurationEditor<T : RunConfigurationBase<*>> : SettingsEditor<T>() {
     private val editorPanel = JPanel(BorderLayout())
     private val enabledCheckbox = JCheckBox("Log compilation")
 

--- a/src/main/java/JitRunConfigurationExtension.kt
+++ b/src/main/java/JitRunConfigurationExtension.kt
@@ -85,7 +85,7 @@ class JitRunConfigurationExtension : RunConfigurationExtension() {
         val logPath = JitWatchSettings.getOrCreate(configuration).lastLogPath
         if (logPath != null) {
             handler.addProcessListener(object : ProcessAdapter() {
-                override fun processTerminated(event: ProcessEvent?) {
+                override fun processTerminated(event: ProcessEvent) {
                     ApplicationManager.getApplication().invokeLater {
                         loadLogAndShowUI(configuration.project, logPath)
                     }

--- a/src/main/java/JitWatchModelService.kt
+++ b/src/main/java/JitWatchModelService.kt
@@ -207,7 +207,7 @@ class JitWatchModelService(private val project: Project) {
             val methodName = methodAttrs[ATTR_NAME]
             val calleeClass = ParseUtil.lookupType(holder, parseDictionary)
             val calleeMethod = StringUtil.replaceXMLEntities(methodName)
-            val builder = StringBuilder(calleeClass)
+            val builder = StringBuilder(calleeClass ?: "<unknown>")
             builder.append(".").append(calleeMethod)
             builder.append(if (inlined) " inlined " else " not inlined ")
             builder.append("(").append(reason).append(")")

--- a/src/main/java/JitWatchModelService.kt
+++ b/src/main/java/JitWatchModelService.kt
@@ -18,7 +18,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.util.containers.isNullOrEmpty
-import com.intellij.util.isFile
+import com.intellij.util.io.isFile
 import org.adoptopenjdk.jitwatch.core.HotSpotLogParser
 import org.adoptopenjdk.jitwatch.core.IJITListener
 import org.adoptopenjdk.jitwatch.core.ILogParseErrorListener

--- a/src/main/java/languages/JitWatchKotlinSupport.kt
+++ b/src/main/java/languages/JitWatchKotlinSupport.kt
@@ -59,11 +59,11 @@ class JitWatchKotlinSupport : JitWatchLanguageSupport<KtClassOrObject, KtCallabl
         val typeMapper = KotlinTypeMapper(
                 BindingContext.EMPTY,
                 ClassBuilderMode.LIGHT_CLASSES,
-                IncompatibleClassTracker.DoNothing,
                 getModuleName(descriptor),
-                // FIXME Figure out how to properly choose JvmTarget
-                JvmTarget.JVM_1_8,
                 KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT,
+                // FIXME Figure out how to properly choose JvmTarget
+                IncompatibleClassTracker.DoNothing,
+                JvmTarget.JVM_1_8,
                 false // FIXME what significance does this have?
         )
         return typeMapper.mapClass(descriptor).internalName.replace('/', '.')
@@ -87,11 +87,11 @@ class JitWatchKotlinSupport : JitWatchLanguageSupport<KtClassOrObject, KtCallabl
         val typeMapper = KotlinTypeMapper(
                 BindingContext.EMPTY,
                 ClassBuilderMode.LIGHT_CLASSES,
-                IncompatibleClassTracker.DoNothing,
                 getModuleName(descriptor),
-                // FIXME Figure out how to properly choose JvmTarget
-                JvmTarget.JVM_1_8,
                 KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT,
+                // FIXME Figure out how to properly choose JvmTarget
+                IncompatibleClassTracker.DoNothing,
+                JvmTarget.JVM_1_8,
                 false // FIXME what significance does this have?
         )
         val signature = typeMapper.mapAsmMethod(descriptor)

--- a/src/main/java/languages/JitWatchKotlinSupport.kt
+++ b/src/main/java/languages/JitWatchKotlinSupport.kt
@@ -4,28 +4,27 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.*
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.util.PsiTreeUtil
 import org.adoptopenjdk.jitwatch.model.MemberSignatureParts
 import org.adoptopenjdk.jitwatch.model.MetaClass
 import org.jetbrains.kotlin.codegen.ClassBuilderMode
 import org.jetbrains.kotlin.codegen.state.IncompatibleClassTracker
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.fileClasses.NoResolveFileClassesProvider
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptor
 import org.jetbrains.kotlin.idea.search.allScope
 import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
-import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
 class JitWatchKotlinSupport : JitWatchLanguageSupport<KtClassOrObject, KtCallableDeclaration> {
@@ -56,11 +55,23 @@ class JitWatchKotlinSupport : JitWatchLanguageSupport<KtClassOrObject, KtCallabl
         return getClassDescriptorVMName(descriptor)
     }
 
-    private fun getClassDescriptorVMName(descriptor: ClassDescriptor): String {
-        val typeMapper = KotlinTypeMapper(BindingContext.EMPTY, ClassBuilderMode.LIGHT_CLASSES, NoResolveFileClassesProvider, null,
-                IncompatibleClassTracker.DoNothing, JvmAbi.DEFAULT_MODULE_NAME)
+    private fun getClassDescriptorVMName(descriptor: ClassifierDescriptorWithTypeParameters): String {
+        val typeMapper = KotlinTypeMapper(
+                BindingContext.EMPTY,
+                ClassBuilderMode.LIGHT_CLASSES,
+                IncompatibleClassTracker.DoNothing,
+                getModuleName(descriptor),
+                // FIXME Figure out how to properly choose JvmTarget
+                JvmTarget.JVM_1_8,
+                KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT,
+                false // FIXME what significance does this have?
+        )
         return typeMapper.mapClass(descriptor).internalName.replace('/', '.')
     }
+
+    private fun getModuleName(descriptor: DeclarationDescriptor) =
+            // FIXME descriptor.module.stableName is '<module-name>' instead of 'module-name' - Is it a good idea to simply try remove <>?
+            descriptor.module.stableName?.toString()?.removeSurrounding("<", ">") ?: "<unknwon>"
 
     override fun getContainingClass(method: KtCallableDeclaration): KtClassOrObject? = method.containingClassOrObject
 
@@ -73,8 +84,16 @@ class JitWatchKotlinSupport : JitWatchLanguageSupport<KtClassOrObject, KtCallabl
     }
 
     private fun matchesSignature(descriptor: FunctionDescriptor, memberName: String, paramTypeNames: List<String>, returnTypeName: String): Boolean {
-        val typeMapper = KotlinTypeMapper(BindingContext.EMPTY, ClassBuilderMode.LIGHT_CLASSES, NoResolveFileClassesProvider, null,
-                IncompatibleClassTracker.DoNothing, JvmAbi.DEFAULT_MODULE_NAME)
+        val typeMapper = KotlinTypeMapper(
+                BindingContext.EMPTY,
+                ClassBuilderMode.LIGHT_CLASSES,
+                IncompatibleClassTracker.DoNothing,
+                getModuleName(descriptor),
+                // FIXME Figure out how to properly choose JvmTarget
+                JvmTarget.JVM_1_8,
+                KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT,
+                false // FIXME what significance does this have?
+        )
         val signature = typeMapper.mapAsmMethod(descriptor)
 
         val expectedName = if (descriptor is ConstructorDescriptor)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,6 @@
     <description><![CDATA[
         Viewing HotSpot compilation logs in IntelliJ IDEA. See <a href="https://github.com/yole/jitwatch-intellij">GitHub</a> for documentation.
     ]]></description>
-    <version>1.0.1</version>
     <change-notes>
         <![CDATA[
         <b>Version 1.0.1</b>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
     ]]></description>
     <version>1.0</version>
     
-    <idea-version since-build="145.1"/>
+    <idea-version since-build="181"/>
 
     <depends optional="true" config-file="plugin-kotlin.xml">org.jetbrains.kotlin</depends>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,15 @@
     <description><![CDATA[
         Viewing HotSpot compilation logs in IntelliJ IDEA. See <a href="https://github.com/yole/jitwatch-intellij">GitHub</a> for documentation.
     ]]></description>
-    <version>1.0</version>
+    <version>1.0.1</version>
+    <change-notes>
+        <![CDATA[
+        <b>Version 1.0.1</b>
+        <ul>
+            <li>Compatibility with IntelliJ 2018.1 and later</li>
+        </ul>
+        ]]>
+    </change-notes>
     
     <idea-version since-build="181"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,11 @@
     ]]></description>
     <change-notes>
         <![CDATA[
+        <b>Version 1.0.2</b>
+        <ul>
+            <li>Compatibility with IntelliJ 2019.2 and later</li>
+            <li>Minimum IntelliJ Version raised to 2019.2</li>
+        </ul>
         <b>Version 1.0.1</b>
         <ul>
             <li>Compatibility with IntelliJ 2018.1 and later</li>

--- a/test-project/.idea/kotlinc.xml
+++ b/test-project/.idea/kotlinc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="1.3" />
+    <option name="languageVersion" value="1.3" />
+  </component>
+</project>

--- a/test-project/.idea/libraries/KotlinJavaRuntime.xml
+++ b/test-project/.idea/libraries/KotlinJavaRuntime.xml
@@ -1,0 +1,19 @@
+<component name="libraryTable">
+  <library name="KotlinJavaRuntime">
+    <CLASSES>
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-reflect.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-test.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-jdk7.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-jdk8.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-sources.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-reflect-sources.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-test-sources.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-jdk7-sources.jar!/" />
+      <root url="jar://$KOTLIN_BUNDLED$/lib/kotlin-stdlib-jdk8-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/test-project/.idea/misc.xml
+++ b/test-project/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/test-project/.idea/modules.xml
+++ b/test-project/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/plugin-debug-jitwatch.iml" filepath="$PROJECT_DIR$/plugin-debug-jitwatch.iml" />
+    </modules>
+  </component>
+</project>

--- a/test-project/.idea/runConfigurations/MyKotlinMain_JITWatch.xml
+++ b/test-project/.idea/runConfigurations/MyKotlinMain_JITWatch.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MyKotlinMain JITWatch" type="JetRunConfigurationType" factoryName="Kotlin">
+    <module name="plugin-debug-jitwatch" />
+    <extension name="ru.yole.jitwatch.JitRunConfigurationExtension" jitwatch-enabled="true" />
+    <option name="VM_PARAMETERS" value="" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <option name="MAIN_CLASS_NAME" value="MyKotlinMain" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/test-project/.idea/runConfigurations/MyMain_JitWatch.xml
+++ b/test-project/.idea/runConfigurations/MyMain_JitWatch.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MyMain JitWatch" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="MyMain" />
+    <module name="plugin-debug-jitwatch" />
+    <extension name="ru.yole.jitwatch.JitRunConfigurationExtension" jitwatch-enabled="true" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/test-project/plugin-debug-jitwatch.iml
+++ b/test-project/plugin-debug-jitwatch.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
+  </component>
+</module>

--- a/test-project/src/MyKotlinMain.kt
+++ b/test-project/src/MyKotlinMain.kt
@@ -1,0 +1,20 @@
+object MyKotlinMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        println("Hello")
+        for (i in 0..1999) {
+            helperMethod()
+        }
+    }
+
+    internal fun factorial(n: Int): Int {
+        return if (n < 2) {
+            1
+        } else n * factorial(n - 1)
+
+    }
+
+    internal fun helperMethod() {
+        println(factorial(20))
+    }
+}

--- a/test-project/src/MyMain.java
+++ b/test-project/src/MyMain.java
@@ -1,0 +1,20 @@
+public class MyMain {
+    public static void main(String[] args) {
+        System.out.println("Hello");
+        for (int i = 0; i < 10000; i++) {
+            helperMethod();
+        }
+    }
+
+    static int factorial(int n) {
+        if (n < 2) {
+            return 1;
+        }
+
+        return n * factorial(n - 1);
+    }
+
+    static void helperMethod() {
+        System.out.println(factorial(20));
+    }
+}


### PR DESCRIPTION
I have updated the plugin to work with both IntelliJ 2019.2 and 2019.3 EAP and Kotlin plugin versions 1.3.41 and 1.3.50


---


I have updated the plugin to work with IntelliJ 2018.1, 2018.2, 2018.3 and 2019.1

The plugin didn't build for me after checkout due to some path handling issue in gradle-intellij-plugin, so I've updated it. This also required a Gradle update.

It's possible to compile the plugin against each version by changing the `platformVersion` property in `gradle.properties`. I've adapted the approach the Rust plugin takes for that.

The Kotlin support seems to be "working" for the simple test case I threw at it. `KotlinTypeMapper` takes different arguments now so I've taken a best guess as to what to pass for the parameters.  